### PR TITLE
chore: 빌드 실패 이슈 해결

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -51,6 +51,14 @@ jobs:
         env:
           NEXT_PUBLIC_TMDB_API_ACCESS_TOKEN: ${{ secrets.TMDB_API_ACCESS_TOKEN }}
 
+      - name: Verify static export output
+        run: |
+          if [[ ! -d "${{ env.DIST_PATH }}" ]]; then
+            echo "❌ Missing export output directory: ${{ env.DIST_PATH }}"
+            echo "Hint: ensure Turbo caches/restores 'out/**' for @movii/web#build (static export)"
+            exit 1
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     },
     "@movii/web#build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**"],
+      "outputs": [".next/**", "out/**"],
       "env": ["NEXT_PUBLIC_TMDB_API_ACCESS_TOKEN"]
     },
     "lint": { "outputs": [] },


### PR DESCRIPTION
## Key Changes 🔑

> PR에 포함된 작업사항들을 요약하여 적습니다.

- [빌드 실패](https://github.com/f-lab-edu/movii/actions/runs/20342729489/job/58447238160) 이슈 해결
	- 원인
		- 워크플로우는 DIST_PATH=apps/movii/out을 기준으로 find를 돌리는데, pnpm build가 turbo로 실행되면서 캐시 히트 시 빌드를 실제로 재실행하지 않고 “outputs로 선언된 것만” 복원합니다.
		- 현재 turbo.json에서 @movii/web#build의 outputs가 ".next/**"만이라서, 캐시 히트가 나면 out/**이 복원되지 않아 out이 없는 상태가 되고, 그 결과 find: ‘apps/movii/out’: No such file or directory가 발생했었습니다.
	- 해결
		- turbo.json에서 @movii/web#build.outputs에 "out/**"을 추가해서 캐시에서도 out이 함께 생기게 했습니다.
		- deploy-prod.yml에는 out 존재 여부를 먼저 체크하는 step을 추가해서, 앞으로는 더 명확한 에러로 실패하게 했습니다.

<br />

## To Reviewers 🙏

> PR 내용 중 리뷰어가 특별히 더 신경써서 봐주었으면 하는 부분이나, 리뷰 시 참고사항 등을 적습니다.

-

<br />

## References

> 관련된 Epic이나 Task 문서 혹은 슬랙 메시지 등의 링크를 나열합니다.

-
